### PR TITLE
Use paths not strings; handle errors with `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,16 @@
 version = 3
 
 [[package]]
+name = "anyhow"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
 name = "git-find-rs"
 version = "0.4.0"
 dependencies = [
+ "anyhow",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 walkdir = "2"
+anyhow = "1.0"


### PR DESCRIPTION
Improves future maintainability at the expense of performance.

```bash
$ hyperfine --warmup 3 './main-git-find-rs $HOME/code' './paths-git-find-rs $HOME/code'
Benchmark 1: ./main-git-find-rs $HOME/code
  Time (mean ± σ):     381.5 µs ± 175.8 µs    [User: 210.4 µs, System: 168.9 µs]
  Range (min … max):    72.1 µs … 1265.3 µs    1088 runs

Benchmark 2: ./paths-git-find-rs $HOME/code
  Time (mean ± σ):      28.5 ms ±   1.3 ms    [User: 3.6 ms, System: 24.7 ms]
  Range (min … max):    26.3 ms …  31.9 ms    95 runs

Summary
  ./main-git-find-rs $HOME/code ran
   74.77 ± 34.61 times faster than ./paths-git-find-rs $HOME/code
```

As [with UIs](https://developer.mozilla.org/en-US/docs/Web/Performance/How_long_is_too_long#responsiveness_goal), <100ms is reasonable.